### PR TITLE
Add ability to run ELMA in simulated time.

### DIFF
--- a/include/manager.h
+++ b/include/manager.h
@@ -41,11 +41,8 @@ namespace elma {
         Manager& update();        
         Manager& stop();
 
-        //! Sets if the manager will run in simulated time.
-        //! In simulated time, the next schefuled process will immediately run at the completion of the last.
-        //! \param If the manager runs in simulated time.
-        //! \return A reference to the manager, for chaining
-        inline Manager& set_simulated_time(bool simulated) { _simulated_time = simulated; };
+        Manager& use_simulated_time();
+        Manager& use_real_time();
 
         Manager& run(high_resolution_clock::duration runtime);
         Manager& run();

--- a/include/manager.h
+++ b/include/manager.h
@@ -28,7 +28,7 @@ namespace elma {
         public: 
 
         //! Default constructor
-        Manager() : _running(false) {}
+        Manager() : _running(false), _simulated_time(false) {}
         
         Manager& schedule(Process& process, high_resolution_clock::duration period);
         Manager& all(std::function<void(Process&)> f);
@@ -40,6 +40,12 @@ namespace elma {
         Manager& start();
         Manager& update();        
         Manager& stop();
+
+        //! Sets if the manager will run in simulated time.
+        //! In simulated time, the next schefuled process will immediately run at the completion of the last.
+        //! \param If the manager runs in simulated time.
+        //! \return A reference to the manager, for chaining
+        inline Manager& set_simulated_time(bool simulated) { _simulated_time = simulated; };
 
         Manager& run(high_resolution_clock::duration runtime);
         Manager& run();
@@ -63,6 +69,9 @@ namespace elma {
         Client& client() { return _client; }
 
         private:
+
+        void update_elapsed_time();
+
         const int Priority_min = -5, Priority_max = 15;
         vector<Process *> _processes;
         map<string, Channel *> _channels;
@@ -71,6 +80,7 @@ namespace elma {
         high_resolution_clock::duration _elapsed;
         Client _client;
         bool _running;
+        bool _simulated_time;
 
     };
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -134,6 +134,23 @@ namespace elma {
 
         return *this;
     }
+
+    //! Sets if the manager will run in simulated time.
+    //! In simulated time, the next schefuled process will immediately run at the completion of the last.
+    //! \return A reference to the manager, for chaining
+    Manager& Manager::use_simulated_time() { 
+        _simulated_time = true; 
+        return *this;
+    };
+
+    //! Sets if the manager will run in real time.
+    //! In real time, the manager will continually advance time until the next process needs to update.
+    //! \param If the manager runs in simulated time.
+    //! \return A reference to the manager, for chaining
+    Manager& Manager::use_real_time() { 
+        _simulated_time = false; 
+        return *this;
+    };
     
     //! Set Process Priority and sort _Processes to ensure higher priority are updated first. 
     //! Priority may be set -5 (low priority) to 15 (high priority)

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -157,18 +157,7 @@ namespace elma {
     //! \return A reference to the manager, for chaining
     Manager& Manager::run(high_resolution_clock::duration runtime) {
 
-        _start_time = high_resolution_clock::now();
-        _elapsed = high_resolution_clock::duration::zero();
-        start();        
-
-        while ( _elapsed < runtime ) {
-            update();
-            update_elapsed_time();
-        }
-
-        stop();
-
-        return *this;
+        return run([&]() { return _elapsed < runtime; });
 
     }
 
@@ -176,18 +165,7 @@ namespace elma {
     //! \return A reference to the manager, for chaining
     Manager& Manager::run() {
 
-        _start_time = high_resolution_clock::now();
-        _elapsed = high_resolution_clock::duration::zero();
-        start();        
-
-        while ( _running ) {
-            update();
-            update_elapsed_time();
-        }
-
-        stop();
-
-        return *this;
+        return run([&]() { return _running; });
 
     }  
 

--- a/test/client.cc
+++ b/test/client.cc
@@ -59,7 +59,7 @@ namespace {
         GetTester p;
         m.schedule(p,1_ms)
          .init()
-         .run([&](){ return p.got_response; });
+         .run([&](){ return !p.got_response; });
     }
 
 }

--- a/test/simulated_time.cc
+++ b/test/simulated_time.cc
@@ -40,7 +40,7 @@ namespace {
         Manager m;
         m.schedule(tp, 10ms)
         .init()
-        .set_simulated_time(true);
+        .use_simulated_time();
 
         auto start = std::chrono::high_resolution_clock::now();
         m.run(1s);

--- a/test/simulated_time.cc
+++ b/test/simulated_time.cc
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <chrono>
+#include "gtest/gtest.h"
+#include "elma.h"
+
+namespace {
+
+    using namespace elma;
+    using std::vector;
+
+    class SimProcess : public Process {
+        public:
+        SimProcess(string name) : Process(name) {}
+        void init() {}
+        void start() {}
+        void update() {}
+        void stop() {}
+    };    
+
+    TEST(SimulatedTime, normal) {
+        SimProcess tp("Normal Process");
+        Manager m;
+        m.schedule(tp, 10_ms)
+        .init();
+
+        auto start = std::chrono::high_resolution_clock::now();
+        m.run(1s);
+        auto end = std::chrono::high_resolution_clock::now();
+
+        auto runtime = end - start;
+
+        EXPECT_TRUE(runtime > 900ms);
+        EXPECT_TRUE(runtime < 1100ms);
+    }
+
+    TEST(SimulatedTime, Simulated) {
+        SimProcess tp("Simulated Process");
+        Manager m;
+        m.schedule(tp, 10ms)
+        .init()
+        .set_simulated_time(true);
+
+        auto start = std::chrono::high_resolution_clock::now();
+        m.run(1s);
+        auto end = std::chrono::high_resolution_clock::now();
+
+        auto runtime = end - start;
+
+        EXPECT_TRUE(runtime > 0s);
+        EXPECT_TRUE(runtime < 100ms);
+    }
+
+}


### PR DESCRIPTION
Implemented a way to run ELMA in simulated time. Instead of always setting elapsed time to `now - start`, have an alternate flow that can instead set it to the time that the next process needs to run. 

Made Manager more DRY by having only one of the run methods do the update loop. The other run methods call into it.

Fixed a bug in Client test where the unit test sent out a http_get but did not wait for it to respond. This caused future unit tests to break because the detached thread would activate after the client was freed.

