### PR TITLE
Sleep the manager when waiting for next process to run.

### DIFF
--- a/include/manager.h
+++ b/include/manager.h
@@ -28,7 +28,7 @@ namespace elma {
         public: 
 
         //! Default constructor
-        Manager() : _running(false), _simulated_time(false) {}
+        Manager() : _running(false), _simulated_time(false), _update_time_calls(0) {}
         
         Manager& schedule(Process& process, high_resolution_clock::duration period);
         Manager& all(std::function<void(Process&)> f);
@@ -64,6 +64,11 @@ namespace elma {
         Manager& watch(string event_name, std::function<void(Event&)> handler);
         Manager& emit(const Event& event);
         Client& client() { return _client; }
+
+        protected: 
+
+        // Used for testing purposes.
+        int _update_time_calls;
 
         private:
 

--- a/include/process.h
+++ b/include/process.h
@@ -97,6 +97,11 @@ namespace elma {
         //! time the Manager called the update() method.        
         inline high_resolution_clock::duration previous_update() { return _previous_update; }
 
+        //! Getter
+        //! \return The duration of time between the start time and the next scheduled  
+        //! time the Manager should call the update() method.
+        inline high_resolution_clock::duration next_update() { return period() * num_updates();};
+
         // documentation for these methods is in process.cc
         Channel& channel(string name);
         double milli_time();

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -225,8 +225,8 @@ namespace elma {
             
             // Find the process that has the smallest time till next update.
             auto min_iter = std::min_element(_processes.begin(), _processes.end() ,[](Process * lhs, Process * rhs) {
-                auto lhsTime = lhs->last_update() + lhs->period();
-                auto rhsTime = rhs->last_update() + rhs->period();
+                auto lhsTime = lhs->next_update();
+                auto rhsTime = rhs->next_update();
                 return lhsTime < rhsTime;
             });
 

--- a/test/sleep_manager.cc
+++ b/test/sleep_manager.cc
@@ -37,7 +37,7 @@ namespace {
     }
 
     TEST(SleepManager, Simulated) {
-        SimProcess tp("Realtime Process");
+        SimProcess tp("Simulated Process");
         TestManager m;
         m.schedule(tp, 10_ms)
         .init()

--- a/test/sleep_manager.cc
+++ b/test/sleep_manager.cc
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <chrono>
+#include "gtest/gtest.h"
+#include "elma.h"
+
+namespace {
+
+    using namespace elma;
+
+    class TestManager : public Manager {
+        public:
+        TestManager() : Manager() {}
+
+        using Manager::_update_time_calls;
+    };
+
+    class SimProcess : public Process {
+        public:
+        SimProcess(string name) : Process(name) {}
+        void init() {}
+        void start() {}
+        void update() {}
+        void stop() {}
+    };    
+
+    TEST(SleepManager, Realtime) {
+        SimProcess tp("Realtime Process");
+        TestManager m;
+        m.schedule(tp, 10_ms)
+        .init()
+        .run([&](){return tp.num_updates() <= 100;});
+        
+        EXPECT_GE(m._update_time_calls, 99);
+        EXPECT_LE(m._update_time_calls, 101);
+    }
+
+    TEST(SleepManager, Simulated) {
+        SimProcess tp("Realtime Process");
+        TestManager m;
+        m.schedule(tp, 10_ms)
+        .init()
+        .use_simulated_time()
+        .run([&](){return tp.num_updates() <= 100;});
+        
+        EXPECT_GE(m._update_time_calls, 99);
+        EXPECT_LE(m._update_time_calls, 101);
+    }
+    
+    TEST(SleepManager, NoProcesses) {
+        TestManager m;
+        m.init()
+        .use_simulated_time()
+        .run(100ms);
+        
+        EXPECT_GT(m._update_time_calls, 1000);
+    }
+
+}


### PR DESCRIPTION
When running real-time processes, sleeps the manager until the next scheduled process is slated to run.